### PR TITLE
Four new email notification defaults and one bugfix

### DIFF
--- a/adm/style/user_defaults.html
+++ b/adm/style/user_defaults.html
@@ -292,7 +292,7 @@
 				<label class="set" for="ud_type_forum_post0">{{ lang('NOTIFICATION') }}</label>
 				<input type="radio" id="ud_type_forum_post1" name="ud_type_forum_post" value="1"{% if NOTIFY_FORUM_POST %} checked="checked"{% endif %} />
 				<label class="set" for="ud_type_forum_post1">{{ lang('EMAIL') }}</label>
-				<label for="ud_type_forum_post">{{ lang('DEFAULT_EMAIL') }}</label>
+				<label for="ud_type_forum_post">{{ lang('DEFAULT_NOTIFICATION') }}</label>
 			</dd>
 		</dl>
 	</fieldset>

--- a/adm/style/user_defaults.html
+++ b/adm/style/user_defaults.html
@@ -284,6 +284,17 @@
 				<label for="ud_type_topic">{{ lang('DEFAULT_EMAIL') }}</label>
 			</dd>
 		</dl>
+
+		<dl>
+			<dt><label for="ud_type_forum_post">{{ lang('REPLY_SUBSCRIBED_FORUM') }}{{ lang('COLON') }}</label></dt>
+			<dd>
+				<input type="radio" id="ud_type_forum_post0" name="ud_type_forum_post" value="0"{% if not NOTIFY_FORUM_POST %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_forum_post0">{{ lang('NOTIFICATION') }}</label>
+				<input type="radio" id="ud_type_forum_post1" name="ud_type_forum_post" value="1"{% if NOTIFY_FORUM_POST %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_forum_post1">{{ lang('EMAIL') }}</label>
+				<label for="ud_type_forum_post">{{ lang('DEFAULT_EMAIL') }}</label>
+			</dd>
+		</dl>
 	</fieldset>
 
 	<fieldset>
@@ -308,6 +319,39 @@
 				<input type="radio" id="ud_type_report1" name="ud_type_report" value="1"{% if NOTIFY_REPORT %} checked="checked"{% endif %} />
 				<label class="set" for="ud_type_report1">{{ lang('EMAIL') }}</label>
 				<label for="ud_type_report">{{ lang('DEFAULT_NOTIFICATION') }}</label>
+			</dd>
+		</dl>
+
+		<dl>
+			<dt><label for="ud_type_pm_report">{{ lang('MODERATOR_PM_REPORT') }}{{ lang('COLON') }}</label></dt>
+			<dd>
+				<input type="radio" id="ud_type_pm_report0" name="ud_type_pm_report" value="0"{% if not NOTIFY_PM_REPORT %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_pm_report0">{{ lang('NOTIFICATION') }}</label>
+				<input type="radio" id="ud_type_pm_report1" name="ud_type_pm_report" value="1"{% if NOTIFY_PM_REPORT %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_pm_report1">{{ lang('EMAIL') }}</label>
+				<label for="ud_type_pm_report">{{ lang('DEFAULT_NOTIFICATION') }}</label>
+			</dd>
+		</dl>
+
+		<dl>
+			<dt><label for="ud_type_close">{{ lang('REPORT_CLOSE') }}{{ lang('COLON') }}</label></dt>
+			<dd>
+				<input type="radio" id="ud_type_close0" name="ud_type_close" value="0"{% if not NOTIFY_CLOSE %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_close0">{{ lang('NOTIFICATION') }}</label>
+				<input type="radio" id="ud_type_close1" name="ud_type_close" value="1"{% if NOTIFY_CLOSE %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_close1">{{ lang('EMAIL') }}</label>
+				<label for="ud_type_close">{{ lang('DEFAULT_NOTIFICATION') }}</label>
+			</dd>
+		</dl>
+
+		<dl>
+			<dt><label for="ud_type_pm_close">{{ lang('PM_REPORT_CLOSE') }}{{ lang('COLON') }}</label></dt>
+			<dd>
+				<input type="radio" id="ud_type_pm_close0" name="ud_type_pm_close" value="0"{% if not NOTIFY_PM_CLOSE %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_pm_close0">{{ lang('NOTIFICATION') }}</label>
+				<input type="radio" id="ud_type_pm_close1" name="ud_type_pm_close" value="1"{% if NOTIFY_PM_CLOSE %} checked="checked"{% endif %} />
+				<label class="set" for="ud_type_pm_close1">{{ lang('EMAIL') }}</label>
+				<label for="ud_type_pm_close">{{ lang('DEFAULT_NOTIFICATION') }}</label>
 			</dd>
 		</dl>
 	</fieldset>

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -257,7 +257,7 @@ class admin_controller implements admin_interface
 		$this->config->set('ud_options', phpbb_optionset($this->constants['viewflash'], $this->request->variable('ud_flash', 0), $this->config['ud_options']));
 		$this->config->set('ud_options', phpbb_optionset($this->constants['viewimg'], $this->request->variable('ud_images', 0), $this->config['ud_options']));
 		$this->config->set('ud_options', phpbb_optionset($this->constants['viewsigs'], $this->request->variable('ud_sigs', 0), $this->config['ud_options']));
-		$this->config->set('ud_options', phpbb_optionset($this->constants['viewsmilies'], $this->request->variable('udl_smilies', 0), $this->config['ud_options']));
+		$this->config->set('ud_options', phpbb_optionset($this->constants['viewsmilies'], $this->request->variable('ud1_smilies', 0), $this->config['ud_options']));
 		$this->config->set('ud_post_sd', $this->request->variable('post_sd', 'a'));
 		$this->config->set('ud_post_sk', $this->request->variable('post_sk', 't'));
 		$this->config->set('ud_post_st', $this->request->variable('post_st', 0));

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -197,10 +197,14 @@ class admin_controller implements admin_interface
 		$this->template->assign_vars(array(
 			'DEFAULT_DATE_FORMAT' 		=> $this->language->lang('DEFAULT_DATE_FORMAT', date($default_dateformat, time())),
 			'NOTIFY_BOOKMARK'			=> isset($this->config['ud_type_bookmark']) ? $this->config['ud_type_bookmark'] : 0,
+			'NOTIFY_CLOSE'				=> isset($this->config['ud_type_close']) ? $this->config['ud_type_close'] : 0,
+			'NOTIFY_FORUM_POST'			=> isset($this->config['ud_type_forum_post']) ? $this->config['ud_type_forum_post'] : 0,
 			'NOTIFY_GROUP'				=> isset($this->config['ud_type_group']) ? $this->config['ud_type_group'] : 0,
 			'NOTIFY_MODERATOR_APPROVAL'	=> isset($this->config['ud_type_needs_approval']) ? $this->config['ud_type_needs_approval'] : 0,
 			'NOTIFY_MODERATION_QUEUE'	=> isset($this->config['ud_moderation_queue']) ? $this->config['ud_moderation_queue'] : 0,
 			'NOTIFY_PM'			  		=> isset($this->config['ud_type_pm']) ? $this->config['ud_type_pm'] : 0,
+			'NOTIFY_PM_CLOSE'			=> isset($this->config['ud_type_pm_close']) ? $this->config['ud_type_pm_close'] : 0,
+			'NOTIFY_PM_REPORT'	  		=> isset($this->config['ud_type_pm_report']) ? $this->config['ud_type_pm_report'] : 0,
 			'NOTIFY_QUOTE'				=> isset($this->config['ud_type_quote']) ? $this->config['ud_type_quote'] : 0,
 			'NOTIFY_REPORT'				=> isset($this->config['ud_type_report']) ? $this->config['ud_type_report'] : 0,
 			'NOTIFY_SUBSCRIBED'			=> isset($this->config['ud_type_post']) ? $this->config['ud_type_post'] : 1,
@@ -265,9 +269,13 @@ class admin_controller implements admin_interface
 		$this->config->set('ud_topic_sk', $this->request->variable('topic_sk', 't'));
 		$this->config->set('ud_topic_st', $this->request->variable('topic_st', 0));
 		$this->config->set('ud_type_bookmark', $this->request->variable('ud_type_bookmark', 0));
+		$this->config->set('ud_type_close', $this->request->variable('ud_type_close', 0));
+		$this->config->set('ud_type_forum_post', $this->request->variable('ud_type_forum_post', 0));
 		$this->config->set('ud_type_group', $this->request->variable('ud_type_group', 0));
 		$this->config->set('ud_type_needs_approval', $this->request->variable('ud_type_needs_approval', 0));
 		$this->config->set('ud_type_pm', $this->request->variable('ud_type_pm', 0));
+		$this->config->set('ud_type_pm_close', $this->request->variable('ud_type_pm_close', 0));
+		$this->config->set('ud_type_pm_report', $this->request->variable('ud_type_pm_report', 0));
 		$this->config->set('ud_type_post', $this->request->variable('ud_type_post', 1));
 		$this->config->set('ud_type_quote', $this->request->variable('ud_type_quote', 0));
 		$this->config->set('ud_type_report', $this->request->variable('ud_type_report', 0));

--- a/event/listener.php
+++ b/event/listener.php
@@ -77,6 +77,16 @@ class listener implements EventSubscriberInterface
 			$notifications_data[] = array('item_type' => 'notification.type.bookmark', 'method' => 'notification.method.email');
 		}
 
+		if ($this->config['ud_type_close'] != $this->constants['notification'])
+		{
+			$notifications_data[] = array('item_type' => 'notification.type.report_post_closed', 'method' => 'notification.method.email');
+		}
+
+		if ($this->config['ud_type_forum_post'] != $this->constants['notification'])
+		{
+			$notifications_data[] = array('item_type' => 'notification.type.forum', 'method' => 'notification.method.email');
+		}
+
 		if ($this->config['ud_type_group'] != $this->constants['notification'])
 		{
 			$notifications_data[] = array('item_type' => 'notification.type.group_request', 'method' => 'notification.method.email');
@@ -90,6 +100,16 @@ class listener implements EventSubscriberInterface
 		if ($this->config['ud_type_pm'] != $this->constants['notification'])
 		{
 			$notifications_data[] = array('item_type' => 'notification.type.pm', 'method' => 'notification.method.email');
+		}
+
+		if ($this->config['ud_type_pm_close'] != $this->constants['notification'])
+		{
+			$notifications_data[] = array('item_type' => 'notification.type.report_pm_closed', 'method' => 'notification.method.email');
+		}
+
+		if ($this->config['ud_type_pm_report'] != $this->constants['notification'])
+		{
+			$notifications_data[] = array('item_type' => 'notification.type.report_pm', 'method' => 'notification.method.email');
 		}
 
 		if ($this->config['ud_type_post'] != $this->constants['notification'])

--- a/language/en/acp_userdefaults.php
+++ b/language/en/acp_userdefaults.php
@@ -65,6 +65,7 @@ $lang = array_merge($lang, array(
 	'MISC_NOTIFICATIONS'		=> 'Miscellaneous notifications',
 	'MODERATOR_APPROVAL'		=> 'A post or topic needs approval',
 	'MODERATOR_NOTIFICATIONS'	=> 'Moderation Notifications',
+	'MODERATOR_PM_REPORT'		=> 'Someone reports a private message',
 	'MODERATOR_REPORT'			=> 'Someone reports a post',
 
 	'NOTIFICATION'				=> 'Notification',

--- a/language/en/acp_userdefaults.php
+++ b/language/en/acp_userdefaults.php
@@ -66,6 +66,9 @@ $lang = array_merge($lang, array(
 	'MODERATOR_APPROVAL'		=> 'A post or topic needs approval',
 	'MODERATOR_NOTIFICATIONS'	=> 'Moderation Notifications',
 	'MODERATOR_REPORT'			=> 'Someone reports a post',
+	'MODERATOR_PM_REPORT'		=> 'Someone reports a private message',
+    'MODERATOR_POST_REPORT_CL'  => 'Moderator closes user report on a post',
+    'MODERATOR_PM_REPORT_CL'    => 'Moderator closes user report on a private message',
 
 	'NOTIFICATION'				=> 'Notification',
 
@@ -77,6 +80,7 @@ $lang = array_merge($lang, array(
 	'REQUEST_GROUP'				=> 'Someone requests to join a group you lead',
 	'REPLY_BOOKMARK_TOPIC'		=> 'Replies to a topic the user has bookmarked',
 	'REPLY_SUBSCRIBED_TOPIC'	=> 'Replies to a topic the user has subscribed to',
+    'REPLY_SUBSCRIBED_FORUM'    => 'Replies to a topic in a forum the user has subscribed to',
 
 	'SEND_PM'					=> 'Someone sends the user a private message',
 

--- a/language/en/acp_userdefaults.php
+++ b/language/en/acp_userdefaults.php
@@ -67,8 +67,8 @@ $lang = array_merge($lang, array(
 	'MODERATOR_NOTIFICATIONS'	=> 'Moderation Notifications',
 	'MODERATOR_REPORT'			=> 'Someone reports a post',
 	'MODERATOR_PM_REPORT'		=> 'Someone reports a private message',
-    'MODERATOR_POST_REPORT_CL'  => 'Moderator closes user report on a post',
-    'MODERATOR_PM_REPORT_CL'    => 'Moderator closes user report on a private message',
+	'MODERATOR_POST_REPORT_CL'	=> 'Moderator closes user report on a post',
+	'MODERATOR_PM_REPORT_CL'	=> 'Moderator closes user report on a private message',
 
 	'NOTIFICATION'				=> 'Notification',
 
@@ -80,7 +80,7 @@ $lang = array_merge($lang, array(
 	'REQUEST_GROUP'				=> 'Someone requests to join a group you lead',
 	'REPLY_BOOKMARK_TOPIC'		=> 'Replies to a topic the user has bookmarked',
 	'REPLY_SUBSCRIBED_TOPIC'	=> 'Replies to a topic the user has subscribed to',
-    'REPLY_SUBSCRIBED_FORUM'    => 'Replies to a topic in a forum the user has subscribed to',
+	'REPLY_SUBSCRIBED_FORUM'	=> 'Replies to a topic in a forum the user has subscribed to',
 
 	'SEND_PM'					=> 'Someone sends the user a private message',
 

--- a/language/en/acp_userdefaults.php
+++ b/language/en/acp_userdefaults.php
@@ -66,12 +66,10 @@ $lang = array_merge($lang, array(
 	'MODERATOR_APPROVAL'		=> 'A post or topic needs approval',
 	'MODERATOR_NOTIFICATIONS'	=> 'Moderation Notifications',
 	'MODERATOR_REPORT'			=> 'Someone reports a post',
-	'MODERATOR_PM_REPORT'		=> 'Someone reports a private message',
-	'MODERATOR_POST_REPORT_CL'	=> 'Moderator closes user report on a post',
-	'MODERATOR_PM_REPORT_CL'	=> 'Moderator closes user report on a private message',
 
 	'NOTIFICATION'				=> 'Notification',
 
+	'PM_REPORT_CLOSE'			=> 'Moderator closes user report on a private message',
 	'POSTING_NOTIFICATIONS'		=> 'Posting notifications',
 	'POSTING_SETTINGS'			=> 'Posting defaults',
 
@@ -81,6 +79,7 @@ $lang = array_merge($lang, array(
 	'REPLY_BOOKMARK_TOPIC'		=> 'Replies to a topic the user has bookmarked',
 	'REPLY_SUBSCRIBED_TOPIC'	=> 'Replies to a topic the user has subscribed to',
 	'REPLY_SUBSCRIBED_FORUM'	=> 'Replies to a topic in a forum the user has subscribed to',
+	'REPORT_CLOSE'				=> 'Moderator closes user report on a post',
 
 	'SEND_PM'					=> 'Someone sends the user a private message',
 


### PR DESCRIPTION
Hi David,

Thanks for writing this extension. It's a big improvement over the 2016 local source code hack I did for 3.1. I forgot to include something similar when I upgraded to 3.3 in December, and of course the email notification settings [went to hell](https://forums.apoe4.info/viewtopic.php?p=83473).

I noticed that four of the email notification types were missing, so I added them. I also found and fixed an unrelated bug in the "Display smilies as images" setting. It was stuck on a red **No** - turns out there was a typo in one of the files. Ones look a lot like ells. :-)

Not sure if it would be useful to you or anyone you know, but I wrote a quick-and-dirty perl script to fix the notification defaults for existing users. It's available at [apoe4info/phpbb-scripts](https://github.com/apoe4info/phpbb-scripts).

I'm new to git, and this is my first pull request - wide open to feedback if I've done any of this poorly. I didn't update the version and plan to rebase (or abandon entirely?) my fork if you merge the changes.

Thanks again for the excellent extension!

Marc